### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ The BAMM formula for Homebrew now lives in [Homebrew/science](https://github.com
 
 Make sure you have [Homebrew](https://brew.sh) installed.  Then run
 
-    brew tap homebrew/science
+    brew tap brewsci/bio
     brew install bamm


### PR DESCRIPTION
`brew tap homebrew/science        `       

> Error: homebrew/science was deprecated. This tap is now empty as all its formulae were migrated.

### Updated brew:

`brew tap brewsci/bio`

> ==> Tapping brewsci/bio
> Cloning into '/usr/local/Homebrew/Library/Taps/brewsci/homebrew-bio'...
> remote: Enumerating objects: 296, done.
> remote: Counting objects: 100% (296/296), done.
> remote: Compressing objects: 100% (293/293), done.
> remote: Total 296 (delta 2), reused 49 (delta 1), pack-reused 0
> Receiving objects: 100% (296/296), 209.65 KiB | 971.00 KiB/s, done.
> Resolving deltas: 100% (2/2), done.
> Tapped 278 formulae (316 files, 641.5KB).

`brew install bamm`

> ==> Installing bamm from brewsci/bio
> ==> Downloading https://linuxbrew.bintray.com/bottles-bio/bamm-2.5.0.sierra.bott
> ==> Downloading from https://akamai.bintray.com/fd/fd57d0a4cee9311723afa3ce19cd8
> ######################################################################## 100.0%
> ==> Pouring bamm-2.5.0.sierra.bottle.tar.gz
> 🍺  /usr/local/Cellar/bamm/2.5.0: 19 files, 1007.6KB