### PR TITLE
Fix tap migration statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 homebrew-bamm
 =============
 
-The BAMM formula for Homebrew now lives in [Homebrew/science](https://github.com/Homebrew/homebrew-science).
+The BAMM formula for Homebrew now lives in [Brewsci/bio](https://github.com/brewsci/homebrew-bio).
 
 Make sure you have [Homebrew](https://brew.sh) installed.  Then run
 

--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -1,3 +1,3 @@
 {
-  "bamm": "homebrew/science"
+  "bamm": "brewsci/bio"
 }


### PR DESCRIPTION
Addresses the error:

> Error: homebrew/science was deprecated. This tap is now empty and all its contents were either deleted or migrated